### PR TITLE
test the router a bit better

### DIFF
--- a/go/routes/router.go
+++ b/go/routes/router.go
@@ -26,11 +26,16 @@ func NewRouter(db *sql.DB) *Router {
 
 // Run sets the routes defined in the router and runs/serves the routes
 func (router *Router) Run() error {
-	router.setRoutes()
+	server := router.server()
+	log.Printf("Router listening on port %s\n", server.Addr)
+	return server.ListenAndServe()
+}
 
+func (router *Router) server() *http.Server {
+	router.mux = chi.NewRouter()
+	router.setRoutes()
 	port := "8080"
-	log.Printf("Router listening on port %s\n", port)
-	return http.ListenAndServe(":"+port, router.mux)
+	return &http.Server{Addr: ":" + port, Handler: router.mux}
 }
 
 func (router *Router) withTx(writer http.ResponseWriter, callback func(tx *sql.Tx) bool) {

--- a/go/routes/router_test.go
+++ b/go/routes/router_test.go
@@ -46,6 +46,18 @@ func StringBody(response *http.Response) (string, error) {
 	return string(body), response.Body.Close()
 }
 
+func TestRouter_server(t *testing.T) {
+	router := DefaultRouter(t)
+	server := router.server()
+
+	if server.Handler != router.mux {
+		t.Error("server.Handler != router.mux")
+	}
+	if server.Addr != ":8080" {
+		t.Error(`server.Addr != ":8080"`)
+	}
+}
+
 func Test_setDefaultRoutes(t *testing.T) {
 	testServer, _, clean := NewRoutedServer(t)
 	defer clean()


### PR DESCRIPTION
Partially to play around with the CI a bit. Used to the old Travis CI (there's a new travis-ci.com and a old travis-ci.org) and make coveralls less restrictive.

Coveralls made `master` have an `x` for the GitHub integration because I created `if` statements for database errors. Coveralls even passed on the PR's branch before merging. Made the coverage threshold decrease 1% to break.